### PR TITLE
Add HttpMethod enum

### DIFF
--- a/examples/api/src/Main.scala
+++ b/examples/api/src/Main.scala
@@ -19,24 +19,24 @@ class JsonApiModule(port: Int) {
   private var db = Seq.empty[ProductRes]
 
   private val routes = Routes:
-    case GET() -> Path("products", param[UUID](id)) =>
+    case GET -> Path("products", param[UUID](id)) =>
       val productOpt = db.find(_.id == id)
       Response.withBodyOpt(productOpt, s"Product with id=$id")
 
-    case GET() -> Path("products") =>
+    case GET -> Path("products") =>
       val query = Request.current.queryParamsValidated[ProductsQuery]
       val products =
         if query.name.isEmpty then db
         else db.filter(c => query.name.contains(c.name) && query.minQuantity.map(c.quantity >= _).getOrElse(true))
       Response.withBody(products.toList)
 
-    case POST() -> Path("products") =>
+    case POST -> Path("products") =>
       val req = Request.current.bodyJsonValidated[CreateProductReq]
       val res = ProductRes(UUID.randomUUID(), req.name, req.quantity)
       db = db.appended(res)
       Response.withBody(res)
 
-    case GET() -> Path("products.json") =>
+    case GET -> Path("products.json") =>
       val tmpFile = Files.createTempFile("product", ".json")
       tmpFile.toFile().deleteOnExit()
       Files.writeString(tmpFile, db.toJson)

--- a/examples/fullstack/src/Main.scala
+++ b/examples/fullstack/src/Main.scala
@@ -15,10 +15,10 @@ class FullstackModule(port: Int) {
   val baseUrl = s"http://localhost:${port}"
 
   private val routes = Routes:
-    case GET() -> Path() =>
+    case GET -> Path() =>
       Response.withBody(ShowFormPage(CreateCustomerForm.empty))
 
-    case POST() -> Path("form-submit") =>
+    case POST -> Path("form-submit") =>
       // note that here we do the validation *manually* !!
       val formData = Request.current.bodyForm[CreateCustomerForm]
       formData.validate match

--- a/examples/oauth2/src/AppRoutes.scala
+++ b/examples/oauth2/src/AppRoutes.scala
@@ -8,13 +8,13 @@ import ba.sake.hepek.html.HtmlPage
 class AppRoutes(securityService: SecurityService) {
 
   val routes = Routes:
-    case GET() -> Path("protected") =>
+    case GET -> Path("protected") =>
       Response.withBody(ProtectedPage)
 
-    case GET() -> Path("login") =>
+    case GET -> Path("login") =>
       Response.redirect("/")
 
-    case GET() -> Path() =>
+    case GET -> Path() =>
       Response.withBody(IndexPage(securityService.currentUser))
 
     case _ =>

--- a/sharaf/src/ba/sake/sharaf/handlers/RoutesHandler.scala
+++ b/sharaf/src/ba/sake/sharaf/handlers/RoutesHandler.scala
@@ -35,17 +35,16 @@ final class RoutesHandler private (routes: Routes, nextHandler: Option[HttpHandl
   }
 
   private def fillReqParams(exchange: HttpServerExchange): RequestParams = {
+    val method = HttpMethod.valueOf(exchange.getRequestMethod.toString)
     val relPath =
       if exchange.getRelativePath.startsWith("/") then exchange.getRelativePath.drop(1)
       else exchange.getRelativePath
     val pathSegments = relPath.split("/")
-
     val path =
       if pathSegments.size == 1 && pathSegments.head == ""
       then Path()
       else Path(pathSegments*)
-
-    (exchange.getRequestMethod, path)
+    (method, path)
   }
 
 }

--- a/sharaf/src/ba/sake/sharaf/routing/httpMethods.scala
+++ b/sharaf/src/ba/sake/sharaf/routing/httpMethods.scala
@@ -1,28 +1,12 @@
 package ba.sake.sharaf.routing
 
 import io.undertow.util.Methods
-import io.undertow.util.HttpString
 
-object GET:
-  def unapply(str: HttpString): Boolean =
-    Methods.GET == str
-
-object POST:
-  def unapply(str: HttpString): Boolean =
-    Methods.POST == str
-
-object PUT:
-  def unapply(str: HttpString): Boolean =
-    Methods.PUT == str
-
-object DELETE:
-  def unapply(str: HttpString): Boolean =
-    Methods.DELETE == str
-
-object OPTIONS:
-  def unapply(str: HttpString): Boolean =
-    Methods.OPTIONS == str
-
-object PATCH:
-  def unapply(str: HttpString): Boolean =
-    Methods.PATCH == str
+enum HttpMethod(val name: String) {
+  case GET extends HttpMethod(Methods.GET_STRING)
+  case POST extends HttpMethod(Methods.POST_STRING)
+  case PUT extends HttpMethod(Methods.PUT_STRING)
+  case DELETE extends HttpMethod(Methods.DELETE_STRING)
+  case OPTIONS extends HttpMethod(Methods.OPTIONS_STRING)
+  case PATCH extends HttpMethod(Methods.PATCH_STRING)
+}

--- a/sharaf/src/ba/sake/sharaf/routing/package.scala
+++ b/sharaf/src/ba/sake/sharaf/routing/package.scala
@@ -1,6 +1,6 @@
 package ba.sake.sharaf
 package routing
 
-import io.undertow.util.HttpString
+type RequestParams = (HttpMethod, Path)
 
-type RequestParams = (HttpString, Path)
+export HttpMethod.*

--- a/sharaf/test/src/ba/sake/sharaf/ResponseWritableTest.scala
+++ b/sharaf/test/src/ba/sake/sharaf/ResponseWritableTest.scala
@@ -8,30 +8,30 @@ import ba.sake.sharaf.routing.*
 import ba.sake.tupson.JsonRW
 
 class ResponseWritableTest extends munit.FunSuite {
-  
+
   val testFileResourceDir = Paths.get(sys.env("MILL_TEST_RESOURCE_DIR"))
 
   val port = utils.getFreePort()
   val baseUrl = s"http://localhost:$port"
-  
+
   val routes = Routes {
-    case GET() -> Path("string") =>
+    case GET -> Path("string") =>
       Response.withBody("a string")
-    case GET() -> Path("inputstream") =>
+    case GET -> Path("inputstream") =>
       val is = new java.io.ByteArrayInputStream("an inputstream".getBytes(StandardCharsets.UTF_8))
       Response.withBody(is)
-    case GET() -> Path("file") =>
+    case GET -> Path("file") =>
       val file = testFileResourceDir.resolve("text_file.txt")
       Response.withBody(file)
-    case GET() -> Path("json") =>
+    case GET -> Path("json") =>
       case class JsonCaseClass(name: String, age: Int) derives JsonRW
       val json = JsonCaseClass("Meho", 40)
       Response.withBody(json)
-    case GET() -> Path("scalatags", "frag") =>
+    case GET -> Path("scalatags", "frag") =>
       import scalatags.Text.all.*
       val res = div("this is a div")
       Response.withBody(res)
-    case GET() -> Path("scalatags", "doctype") =>
+    case GET -> Path("scalatags", "doctype") =>
       import scalatags.Text.all.{title =>_, *}
       import scalatags.Text.tags2.title
       val res = doctype("html")(
@@ -45,7 +45,7 @@ class ResponseWritableTest extends munit.FunSuite {
         )
       )
       Response.withBody(res)
-    case GET() -> Path("hepek", "htmlpage") =>
+    case GET -> Path("hepek", "htmlpage") =>
       import scalatags.Text.all.*
       import ba.sake.hepek.html.HtmlPage
       val page = new HtmlPage {
@@ -53,13 +53,13 @@ class ResponseWritableTest extends munit.FunSuite {
       }
       Response.withBody(page)
   }
-  
+
   val server = Undertow
     .builder()
     .addHttpListener(port, "localhost")
     .setHandler(SharafHandler(routes))
     .build()
-  
+
   override def beforeAll(): Unit = server.start()
 
   override def afterAll(): Unit = server.stop()
@@ -107,6 +107,4 @@ class ResponseWritableTest extends munit.FunSuite {
     assertEquals(res.headers(Headers.CONTENT_TYPE_STRING.toLowerCase), Seq("text/html; charset=utf-8"))
   }
   
-
 }
-


### PR DESCRIPTION
This makes matching a bit cleaner.  
And 2 characters shorter, yay!

You can use this regex to find+replace:
- find `case (GET|POST|PUT|DELETE|OPTIONS|PATCH)\(\)`
- replace with `case $1`