### PR TITLE
Fix matching `Path`s on values

### DIFF
--- a/sharaf/src/ba/sake/sharaf/Path.scala
+++ b/sharaf/src/ba/sake/sharaf/Path.scala
@@ -6,6 +6,16 @@ final class Path private (
   override def toString(): String =
     val p = segments.mkString("/")
     s"Path($p)"
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: Path =>
+        this.segments == that.segments
+      case _ => false
+    }
+
+  override def hashCode(): Int =
+    segments.hashCode()
 }
 
 object Path:

--- a/sharaf/test/src/ba/sake/sharaf/routing/PathTest.scala
+++ b/sharaf/test/src/ba/sake/sharaf/routing/PathTest.scala
@@ -54,6 +54,23 @@ class PathTest extends munit.FunSuite {
 
   }
 
+  test("match on value") {
+    val path = Path("hello")
+
+    Path("hello") match
+      case `path` => // ok
+      case _ =>
+        fail("Did not match path")
+  }
+
+  test("equals") {
+    assertEquals(Path("hello"), Path("hello"))
+    assertNotEquals(Path("world"), Path("hello"))
+  }
+
+  test("hashCode") {
+    assertEquals(Path("hello").hashCode(), Path("hello").hashCode())
+  }
 }
 
 enum Sort derives FromPathParam:


### PR DESCRIPTION
Implement custom `equals` and `hashCode`
