### PR TITLE
Add http4s module to expose a http4s app

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.0
+//| mill-version: 1.0.6
 package build
 
 import mill.*
@@ -44,6 +44,23 @@ object `sharaf-undertow` extends SharafPublishModule:
       mvn"org.webjars:jquery:3.7.1"
     )
 
+object `sharaf-http4s` extends Module:
+  object jvm extends SharafHttp4sModule with PlatformScalaModule:
+    def moduleDeps = Seq(`sharaf-core`.jvm)
+    object test extends TestModule
+  // object native extends SharafHttp4sModule with ScalaNativeCommonModule with PlatformScalaModule:
+  //   def moduleDeps = Seq(`sharaf-core`.native)
+  //   object test extends ScalaNativeTests with TestModule
+  trait SharafHttp4sModule extends SharafPublishModule:
+    def artifactName = "sharaf-https"
+    def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"org.http4s::http4s-server::0.23.32"
+    )
+    trait TestModule extends ScalaTests with SharafTestModule:
+      def mvnDeps = super.mvnDeps() ++ Seq(
+        mvn"org.http4s::http4s-client::0.23.32"
+      )
+
 object `sharaf-helidon` extends SharafPublishModule:
   def artifactName = "sharaf-helidon"
   def mvnDeps = super.mvnDeps() ++ Seq(
@@ -79,7 +96,7 @@ trait SharafPublishModule extends SharafCommonModule with SonatypeCentralPublish
 
 
 trait SharafCommonModule extends ScalaModule:
-  def scalaVersion = "3.7.1"
+  def scalaVersion = "3.7.3"
   def scalacOptions = super.scalacOptions() ++ Seq(
     "-Yretain-trees", // needed for default parameters
     "-deprecation",
@@ -102,7 +119,7 @@ trait ScalaJSCommonModule extends ScalaJSModule:
   )
 
 trait ScalaNativeCommonModule extends ScalaNativeModule:
-  def scalaNativeVersion = "0.5.7"
+  def scalaNativeVersion = "0.5.9"
   def mvnDeps = super.mvnDeps() ++ Seq(
     mvn"io.github.cquiroz::scala-java-time::2.6.0"
   )

--- a/docs/content/tutorials/quickstart.md
+++ b/docs/content/tutorials/quickstart.md
@@ -49,5 +49,6 @@ scala my_script.sc --scala-option -Yretain-trees
 - [JWT auth]({{site.data.project.gh.sourcesUrl}}/examples/jwt) with [Pac4J](https://www.pac4j.org/)
 - [OAuth2 login]({{site.data.project.gh.sourcesUrl}}/examples/oauth2) with [Pac4J](https://www.pac4j.org/)
 - [Snunit]({{site.data.project.gh.sourcesUrl}}/examples/snunit) demo app
+- [Http4s]({{site.data.project.gh.sourcesUrl}}/examples/http4s) demo app
 - [PetClinic](https://github.com/sake92/sharaf-petclinic) implementation, featuring full-stack app with Postgres db, config, integration tests etc.
 - [Giter8 template for fullstack app](https://github.com/sake92/sharaf-fullstack.g8)

--- a/examples/http4s/README.md
+++ b/examples/http4s/README.md
@@ -1,0 +1,17 @@
+The following steps are done from root of this git repo.
+
+----
+Run from repo root:
+
+```scala
+
+./mill examples.http4s.jvm.run
+
+```
+
+Then in another shell:
+
+```shell
+curl localhost:8080
+# should return "Hello Http4s!"
+```

--- a/examples/http4s/src/Main.scala
+++ b/examples/http4s/src/Main.scala
@@ -1,0 +1,23 @@
+import ba.sake.sharaf.*
+import ba.sake.sharaf.http4s.*
+
+import cats.effect.*
+import com.comcast.ip4s.*
+import org.http4s.ember.server.*
+
+val routes = Routes {
+  case GET -> Path("hello", name) =>
+    Response.withBody(s"Hello ${name}!")
+  case _ =>
+    Response.withBody("Hello Http4s!")
+}
+
+object Main extends IOApp.Simple:
+  def run =
+    EmberServerBuilder
+      .default[cats.effect.IO]
+      .withHost(ipv4"0.0.0.0")
+      .withPort(port"8080")
+      .withHttpApp(SharafHttpApp(SharafHandler.routes(routes)))
+      .build
+      .useForever

--- a/examples/package.mill
+++ b/examples/package.mill
@@ -52,4 +52,14 @@ object `package` extends Module:
 
   object snunit extends SharafExampleModule with ScalaNativeCommonModule:
     def moduleDeps = Seq(`sharaf-snunit`)
+  object http4s extends Module:
+    trait HttpsModule extends SharafExampleModule:
+      def mvnDeps = super.mvnDeps() ++ Seq(
+        mvn"org.http4s::http4s-ember-server::0.23.32"
+      )
+
+    object jvm extends HttpsModule with PlatformScalaModule:
+      def moduleDeps = Seq(build.`sharaf-http4s`.jvm)
+    // object native extends HttpsModule with ScalaNativeCommonModule with PlatformScalaModule:
+    //   def moduleDeps = Seq(build.`sharaf-http4s`.native)
 end `package`

--- a/sharaf-http4s/src/ba/sake/sharaf/http4s/SharafHttpApp.scala
+++ b/sharaf-http4s/src/ba/sake/sharaf/http4s/SharafHttpApp.scala
@@ -1,0 +1,51 @@
+package ba.sake.sharaf.http4s
+
+import ba.sake.sharaf.*
+import cats.data.Kleisli
+import cats.effect.*
+import org.http4s.*
+import org.typelevel.ci.*
+
+def SharafHttpApp(sharafHandler: SharafHandler) =
+  Kleisli[IO, Http4sRequest, Http4sResponse] { (http4sRequest: Http4sRequest) =>
+    for
+      request <- IO.pure(Http4sSharafRequest(http4sRequest))
+      path <- IO.pure(Path(http4sRequest.uri.path.segments.map(_.encoded)*))
+      method <- IO.pure(http4sRequest.method match {
+        case org.http4s.Method.GET     => HttpMethod.GET
+        case org.http4s.Method.POST    => HttpMethod.POST
+        case org.http4s.Method.PUT     => HttpMethod.PUT
+        case org.http4s.Method.DELETE  => HttpMethod.DELETE
+        case org.http4s.Method.OPTIONS => HttpMethod.OPTIONS
+        case org.http4s.Method.PATCH   => HttpMethod.PATCH
+        case org.http4s.Method.HEAD    => HttpMethod.HEAD
+      })
+      requestParams <- IO.pure((method, path))
+      response <- IO.blocking(sharafHandler.handle(RequestContext(requestParams, request)))
+
+      headers <- IO.pure(Headers(response.headerUpdates.updates.flatMap {
+        case HeaderUpdate.Set(name, values) =>
+          values.map(value => Header.Raw(CIString(name.value), value))
+        case HeaderUpdate.Remove(name) =>
+          Seq.empty // TODO: remove header
+      }))
+
+      body <- IO.pure(response.body match {
+        case Some(body) =>
+          fs2.io.readOutputStream(4096)(outputStream => IO.blocking(response.rw.write(body, outputStream)))
+        case None =>
+          fs2.Stream.empty[IO]
+      })
+
+      response <- IO.pure(
+        Http4sResponse[IO](
+          status = Status
+            .fromInt(response.status.code)
+            .getOrElse(throw exceptions.SharafException(s"${response.status} can't be converted to org.http4s.Status")),
+          httpVersion = HttpVersion.`HTTP/1.1`,
+          headers = headers,
+          body = body
+        )
+      )
+    yield response
+  }

--- a/sharaf-http4s/src/ba/sake/sharaf/http4s/SnunitSharafRequest.scala
+++ b/sharaf-http4s/src/ba/sake/sharaf/http4s/SnunitSharafRequest.scala
@@ -1,0 +1,59 @@
+package ba.sake.sharaf.http4s
+
+import cats.effect.*
+import cats.effect.unsafe.implicits.global
+import ba.sake.formson.*
+import ba.sake.querson.*
+import ba.sake.sharaf.*
+import org.http4s.UrlForm
+
+import scala.collection.immutable.SeqMap
+
+class Http4sSharafRequest(underlyingRequest: Http4sRequest) extends Request {
+
+  /* *** HEADERS *** */
+  def headers: Map[HttpString, Seq[String]] =
+    underlyingRequest.headers.headers
+      .groupBy(_.name)
+      .map { (name, headers) =>
+        HttpString(name.toString) -> headers.map(_.value)
+      }
+
+  def cookies: Seq[Cookie] =
+    underlyingRequest.cookies.map { cookie =>
+      Cookie(name = cookie.name, value = cookie.content)
+    }
+
+  /* *** QUERY *** */
+  override lazy val queryParamsRaw: QueryStringMap =
+    underlyingRequest.uri.query.multiParams
+
+  /* *** BODY *** */
+  override lazy val bodyString: String =
+    underlyingRequest.body.through(fs2.text.utf8.decode).compile.string.unsafeRunSync()
+
+  def bodyFormRaw: FormDataMap =
+    val io = for
+      urlForm <- underlyingRequest.as[UrlForm]
+      builder <- IO(SeqMap.newBuilder[String, Seq[FormValue]])
+      _ <- IO {
+        urlForm.values.foreach { case (key, values) =>
+          key -> values.map { value =>
+            FormValue.Str(value)
+          }.toList
+        }
+      }
+      result <- IO(builder.result())
+    yield result
+
+    io.unsafeRunSync()
+
+  override def toString(): String =
+    s"Http4sSharafRequest(headers=${headers}, cookies=${cookies}, queryParamsRaw=${queryParamsRaw}, bodyString=...)"
+}
+
+object Http4sSharafRequest {
+
+  def create(underlyingRequest: Http4sRequest): Http4sSharafRequest =
+    Http4sSharafRequest(underlyingRequest)
+}

--- a/sharaf-http4s/src/ba/sake/sharaf/http4s/types.scala
+++ b/sharaf-http4s/src/ba/sake/sharaf/http4s/types.scala
@@ -1,0 +1,8 @@
+package ba.sake.sharaf.http4s
+
+import cats.effect.*
+
+type Http4sRequest = org.http4s.Request[IO]
+
+type Http4sResponse = org.http4s.Response[IO]
+val Http4sResponse = org.http4s.Response

--- a/sharaf-http4s/test/src/ba/sake/sharaf/http4s/SharafHttpAppTest.scala
+++ b/sharaf-http4s/test/src/ba/sake/sharaf/http4s/SharafHttpAppTest.scala
@@ -1,0 +1,19 @@
+package ba.sake.sharaf.http4s
+
+import ba.sake.sharaf.*
+import ba.sake.sharaf.http4s.*
+import cats.effect.unsafe.implicits.global
+import org.http4s.client.*
+
+class SharafHttpAppTest extends munit.FunSuite {
+
+  test("Hello") {
+    val app = SharafHttpApp(SharafHandler.routes(Routes { case GET -> Path("hello") =>
+      Response.withBody("Hello World!")
+    }))
+
+    val response = Client.fromHttpApp(app).expect[String]("http://localhost:8080/hello").unsafeRunSync()
+
+    assertEquals(response, "Hello World!")
+  }
+}


### PR DESCRIPTION
The Scala Native build is commented out since http4s has not been released yet for Scala Native.

```scala
import ba.sake.sharaf.*
import ba.sake.sharaf.http4s.*

import cats.effect.*
import com.comcast.ip4s.*
import org.http4s.ember.server.*

val routes = Routes {
  case GET -> Path("hello", name) =>
    Response.withBody(s"Hello ${name}!")
  case _ =>
    Response.withBody("Hello Http4s!")
}

object Main extends IOApp.Simple:
  def run =
    EmberServerBuilder
      .default[cats.effect.IO]
      .withHost(ipv4"0.0.0.0")
      .withPort(port"8080")
      .withHttpApp(SharafHttpApp(SharafHandler.routes(routes)))
      .build
      .useForever
```