### PR TITLE
Sharaf http4s native

### DIFF
--- a/.deder/server.properties
+++ b/.deder/server.properties
@@ -1,2 +1,0 @@
-
-#logLevel=debug

--- a/.deder/server.properties
+++ b/.deder/server.properties
@@ -1,3 +1,2 @@
-version=v0.0.21
 
 #logLevel=debug

--- a/deder.pkl
+++ b/deder.pkl
@@ -248,6 +248,7 @@ local const sharafHttp4sModules =
       }
     }
     nativeTestTemplate = (nativeTemplate.asTest()) {
+      multithreading = true
       deps {
         "org.scalameta::munit::1.1.0"
         "org.http4s::http4s-client::0.23.34"

--- a/deder.pkl
+++ b/deder.pkl
@@ -451,3 +451,4 @@ modules {
   ...snunitExampleModules.all
   ...http4sExampleModules.all
 }
+

--- a/deder.pkl
+++ b/deder.pkl
@@ -1,4 +1,4 @@
-amends "https://sake92.github.io/deder/config/early-access/DederProject.pkl"
+amends "https://sake92.github.io/deder/config/v0.2.3/DederProject.pkl"
 
 local const function pomSettings(
   _artifactId: String,

--- a/deder.pkl
+++ b/deder.pkl
@@ -1,4 +1,4 @@
-amends "https://sake92.github.io/deder/config/v0.2.1/DederProject.pkl"
+amends "https://sake92.github.io/deder/config/v0.2.2/DederProject.pkl"
 
 local const function pomSettings(
   _artifactId: String,
@@ -170,12 +170,6 @@ local const sharafCoreModules =
       }
     }
     testTemplate = (sharafCoreTemplate.asTest()) {
-      deps { "org.scalameta::munit::1.1.0" }
-    }
-    jsTemplate = (sharafCoreTemplate.asJs()) {
-      scalaJsVersion = versions.scalaJsVersion
-    }
-    jsTestTemplate = (jsTemplate.asTest()) {
       deps { "org.scalameta::munit::1.1.0" }
     }
     nativeTemplate = (sharafCoreTemplate.asNative()) {

--- a/deder.pkl
+++ b/deder.pkl
@@ -1,4 +1,4 @@
-amends "https://sake92.github.io/deder/config/v0.2.2/DederProject.pkl"
+amends "https://sake92.github.io/deder/config/early-access/DederProject.pkl"
 
 local const function pomSettings(
   _artifactId: String,

--- a/deder.pkl
+++ b/deder.pkl
@@ -1,4 +1,4 @@
-amends "https://sake92.github.io/deder/config/DederProject.pkl"
+amends "https://sake92.github.io/deder/config/v0.2.1/DederProject.pkl"
 
 local const function pomSettings(
   _artifactId: String,

--- a/deder.pkl
+++ b/deder.pkl
@@ -228,19 +228,35 @@ local const sharafUndertowModules =
   }.get
 
 local const sharafHttp4sModules =
-  new CreateScalaModules {
+  new CreateCrossModules {
     root = "sharaf-http4s"
+    local const _pomSettings =
+      pomSettings("sharaf-http4s", "Sharaf Http4s", "Sharaf integration with Http4s")
     template = (baseTemplate) {
-      pomSettings = pomSettings("sharaf-http4s", "Sharaf Http4s", "Sharaf integration with Http4s")
-      moduleDeps {
-        sharafCoreModules.jvm
-      }
-      deps { "org.http4s::http4s-server::0.23.32" }
+      pomSettings = _pomSettings
+      moduleDeps { sharafCoreModules.jvm }
+      deps { "org.http4s::http4s-server::0.23.34" }
     }
     testTemplate = (baseTemplate.asTest()) {
       deps {
         "org.scalameta::munit::1.1.0"
-        "org.http4s::http4s-client::0.23.32"
+        "org.http4s::http4s-client::0.23.34"
+      }
+    }
+    nativeTemplate = (baseTemplate.asNative()) {
+      scalaNativeVersion = versions.scalaNativeVersion
+      pomSettings = _pomSettings
+      moduleDeps { sharafCoreModules.native }
+      deps {
+        "org.http4s::http4s-server::0.23.34"
+        "com.lihaoyi::sourcecode::0.4.2"
+        "io.github.cquiroz::scala-java-time::2.6.0"
+      }
+    }
+    nativeTestTemplate = (nativeTemplate.asTest()) {
+      deps {
+        "org.scalameta::munit::1.1.0"
+        "org.http4s::http4s-client::0.23.34"
       }
     }
   }.get
@@ -403,7 +419,7 @@ local const http4sExampleModules =
   new CreateScalaModules {
     root = "examples/http4s"
     template = (baseExampleTemplate) {
-      moduleDeps { sharafHttp4sModules.main }
+      moduleDeps { sharafHttp4sModules.jvm }
       deps { "org.http4s::http4s-ember-server::0.23.32" }
     }
     testTemplate = (baseExampleTemplate.asTest()) {
@@ -425,7 +441,10 @@ modules {
   sharafCoreModules.native
   sharafCoreModules.native_test
   ...sharafUndertowModules.all
-  ...sharafHttp4sModules.all
+  sharafHttp4sModules.jvm
+  sharafHttp4sModules.jvm_test
+  sharafHttp4sModules.native
+  sharafHttp4sModules.native_test
   ...sharafHelidonModules.all
   ...sharafJdkHttpserverModules.all
   sharafSnunit

--- a/examples/api/test/src/JsonApiSuite.scala
+++ b/examples/api/test/src/JsonApiSuite.scala
@@ -75,7 +75,6 @@ class JsonApiSuite extends munit.FunSuite {
     }
 
     // filtering GET
-    // TODO reenable
     locally {
       val queryParams = ProductsQuery(Set("Chocolate"), Option(1)).toSttpQuery()
       val res = quickRequest.get(uri"$baseUrl/products".withParams(queryParams)).send()

--- a/sharaf-http4s/src/ba/sake/sharaf/http4s/SharafHttpApp.scala
+++ b/sharaf-http4s/src/ba/sake/sharaf/http4s/SharafHttpApp.scala
@@ -30,12 +30,16 @@ def SharafHttpApp(sharafHandler: SharafHandler) =
           Seq.empty // TODO: remove header
       }))
 
-      body <- IO.pure(response.body match {
+      body <- response.body match {
         case Some(body) =>
-          fs2.io.readOutputStream(4096)(outputStream => IO.blocking(response.rw.write(body, outputStream)))
+          IO.blocking {
+            val baos = new java.io.ByteArrayOutputStream()
+            response.rw.write(body, baos)
+            fs2.Stream.emits[IO, Byte](baos.toByteArray())
+          }
         case None =>
-          fs2.Stream.empty[IO]
-      })
+          IO.pure(fs2.Stream.empty[IO])
+      }
 
       response <- IO.pure(
         Http4sResponse[IO](


### PR DESCRIPTION
Replaces https://github.com/sake92/sharaf/pull/73

@lolgab Can you test it locally please?  
IDK if my fix is correct, I was getting error about `fs2.io.readOutputStream`.

This is how I tested it:

```shell
deder exec -t publishLocal
```

and then created `hello-http4s-native.scala`

```scala
//> using scala 3.7.4
//> using platform native
//> using nativeVersion 0.5.9
//> using dep ba.sake::sharaf-http4s::0.17.1-SNAPSHOT
//> using dep org.http4s::http4s-ember-server::0.23.34
//> using repository m2Local

import cats.effect.*
import com.comcast.ip4s.*
import org.http4s.ember.server.*
import ba.sake.sharaf.*
import ba.sake.sharaf.http4s.*

val routes = Routes:
  case GET -> Path("hello", name) =>
    Response.withBody(s"Hello $name")
  case GET -> _ =>
    Response.withBody("Go to http://localhost:8181/hello/your-name")

object Main extends IOApp.Simple:
  def run =
    EmberServerBuilder
      .default[cats.effect.IO]
      .withHost(ipv4"0.0.0.0")
      .withPort(port"8181")
      .withHttpApp(SharafHttpApp(SharafHandler.routes(routes)))
      .build
      .useForever
```

```shell
scala --power package hello-http4s-native.scala -o http4s
./http4s
```